### PR TITLE
Fix Scala Center link reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ software and helping you sharpen your open-source Scala skills.
 
 If you like this work and have the financial means, we encourage you to either donate to the
 open-source Scala community or the [Scala Center](https://scala.epfl.ch).
-If you're a company, we encourage you to become an [Scala Center's Advisory Board member](scalacenter)
+If you're a company, we encourage you to become an [Scala Center's Advisory Board member][scalacenter]
 and have a say in our projects and the future of the Scala language.
 
 The interactions on this repository and its ecosystem are governed by the [Scala Code of Conduct](https://www.scala-lang.org/conduct.html).


### PR DESCRIPTION
Syntax typo was producing a link to a (nonexistent) relative file, instead of a reference.

While we're at it, should this link go directly to <https://scala.epfl.ch/corporate-membership.html> instead of the FAQs page? If so I'll update the PR.